### PR TITLE
Added Pause option to Recurrent payments

### DIFF
--- a/src/app/Http/Controllers/ExpenseController.php
+++ b/src/app/Http/Controllers/ExpenseController.php
@@ -42,6 +42,9 @@ class ExpenseController extends Controller
                 $expense->description = $recurrent_expense->description;
                 $expense->category_id = $recurrent_expense->category_id;
                 $expense->recurrent_expense_id = $recurrent_expense->id;
+
+                // Save the referer in the session to redirect back to it after saving the expense
+                $request->session()->put('back_to', request()->headers->get('referer'));
             }
         }
 
@@ -95,7 +98,19 @@ class ExpenseController extends Controller
             return redirect(route('expense.create'))->with('error', 'Error Saving!');
         }
 
-        return redirect(route('expense.index'))->with('success', 'Expense Created!');
+        $back_to = $request->session()
+            ->get('back_to', route('expense.index'));
+
+        $request->session()->forget('back_to');
+        return redirect($back_to)->with('success', 'Expense Created!');
+    }
+
+    public function edit(Expense $expense)
+    {
+        return view('pages.expense.form', [
+            'model' => $expense,
+            'recurrent_expenses' => RecurrentExpense::getAllNotUsedFirst(Auth::id()),
+        ]);
     }
 
     public function update(Request $request, Expense $expense)
@@ -136,14 +151,6 @@ class ExpenseController extends Controller
             return redirect(route('expense.edit', ['id' => $expense->id]))
                 ->with('error', 'Error Saving!');
         }
-    }
-
-    public function edit(Expense $expense)
-    {
-        return view('pages.expense.form', [
-            'model' => $expense,
-            'recurrent_expenses' => RecurrentExpense::getAllNotUsedFirst(Auth::id()),
-        ]);
     }
 
     public function delete(Expense $expense)

--- a/src/app/Http/Controllers/HomeController.php
+++ b/src/app/Http/Controllers/HomeController.php
@@ -50,9 +50,11 @@ class HomeController extends Controller
     public function pending()
     {
         $recurrentExpensePendingPayment = RecurrentExpense::getPendingToPayThisMonth(Auth::id());
+        $recurrentExpensesPaused = RecurrentExpense::getPendingPausedToPayThisMonth(Auth::id());
 
         return view('pages/expense/pending', [
             'recurrent_expense_pending_payment' => $recurrentExpensePendingPayment,
+            'recurrent_expenses_paused' => $recurrentExpensesPaused,
         ]);
     }
 }

--- a/src/app/Http/Controllers/RecurrentExpenseController.php
+++ b/src/app/Http/Controllers/RecurrentExpenseController.php
@@ -82,4 +82,10 @@ class RecurrentExpenseController extends Controller
         return redirect(route('recurrent_expense.index'))
             ->with('success', 'Expense deleted!');
     }
+
+    public function stateToggle(RecurrentExpense $recurrent_expense) {
+        $recurrent_expense->paused = !$recurrent_expense->paused;
+        $recurrent_expense->save();
+        return back()->with('success', 'Recurrent Expense Updated!');
+    }
 }

--- a/src/app/Http/Controllers/WalletController.php
+++ b/src/app/Http/Controllers/WalletController.php
@@ -35,6 +35,9 @@ class WalletController extends Controller
 
     public function edit(Wallet $wallet)
     {
+        // Save the referer in the session to redirect back to it after saving the expense
+        request()->session()->put('back_to', request()->headers->get('referer'));
+
         return view('pages.wallet.form', [
             'model' => $wallet,
         ]);
@@ -58,7 +61,6 @@ class WalletController extends Controller
             DB::beginTransaction();
             $wallet->save();
 
-
             if ($request->input('update_transactions', false) == 'on') {
                 Expense::updateCurrency($wallet);
                 Income::updateCurrency($wallet);
@@ -69,7 +71,12 @@ class WalletController extends Controller
         }
 
         DB::commit();
-        return redirect(route('wallet.index'))->with('success', 'Wallet updated!');
+
+        $back_to = $request->session()
+            ->get('back_to', route('wallet.index'));
+
+        $request->session()->forget('back_to');
+        return redirect($back_to)->with('success', 'Wallet updated!');
     }
 
     public function delete(Wallet $wallet)

--- a/src/app/Models/RecurrentExpense.php
+++ b/src/app/Models/RecurrentExpense.php
@@ -80,6 +80,7 @@ class RecurrentExpense extends Expense
     public static function getAllNotUsedFirst($userId)
     {
         return self::query()
+            ->where('paused', false)
             ->orderBy('last_use_date')
             ->get();
     }
@@ -89,6 +90,17 @@ class RecurrentExpense extends Expense
         $time = Carbon::now()->endOfMonth()->format('Y-m-d');
 
         return self::query()
+            ->where('paused', false)
+            ->whereRaw('DATE_ADD(last_use_date, INTERVAL period MONTH) < "' . $time . '"')
+            ->get();
+    }
+
+    public static function getPendingPausedToPayThisMonth($userId)
+    {
+        $time = Carbon::now()->endOfMonth()->format('Y-m-d');
+
+        return self::query()
+            ->where('paused', true)
             ->whereRaw('DATE_ADD(last_use_date, INTERVAL period MONTH) < "' . $time . '"')
             ->get();
     }

--- a/src/database/migrations/2023_09_04_161418_pause_recurrent_payments.php
+++ b/src/database/migrations/2023_09_04_161418_pause_recurrent_payments.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasColumn('recurrent_expense', 'paused')) {
+            Schema::table('recurrent_expense', function (Blueprint $table) {
+                $table->boolean('paused')->default(false);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('recurrent_expense', 'paused')) {
+            Schema::table('recurrent_expense', function (Blueprint $table) {
+                $table->dropColumn(['paused']);
+            });
+        }
+    }
+};

--- a/src/resources/views/includes/_recurrent_expense_table.blade.php
+++ b/src/resources/views/includes/_recurrent_expense_table.blade.php
@@ -47,9 +47,13 @@
             </td>
             <td class="text-right">
                 @if ($use_pay_button)
-                    <a class="btn btn-success pay btn-sm"
+                    <a class="btn-primary btn pay btn-sm"
                         href="{{ route('expense.create', ['recurrent_expense' => $recurrent->id]) }}">
                         {{ __('Pay') }}
+                    </a>
+                    <a class="btn @if ($recurrent->paused) btn-success @else btn-danger @endif pay btn-sm"
+                       href="{{ route('recurrent_expense.state_toggle', ['recurrent_expense' => $recurrent->id]) }}">
+                        @if ($recurrent->paused) {{ __('Unpause') }} @else {{ __('Pause') }} @endif
                     </a>
                 @else
                     <span class="btn btn-info fill-expense"

--- a/src/resources/views/pages/expense/pending.blade.php
+++ b/src/resources/views/pages/expense/pending.blade.php
@@ -28,6 +28,23 @@
             </strong>
         @endif
     </div>
+    <div class="">
+        @if (count($recurrent_expenses_paused) > 0)
+            <h1 class="mb-4 "><i class="fa-solid fa-bell"></i> {{ __('Paused Pending Payments') }}</h1>
+
+            @include('includes._recurrent_expense_table',
+                ['recurrent_expenses' => $recurrent_expenses_paused,
+                'use_pay_button' => true])
+        @endif
+    </div>
+    <div class="mt-4 mb-3 text-right">
+        @if (count($recurrent_expenses_paused) > 0)
+            <strong>
+                {{ __('Pending Payments Paused:') }} ({{ count($recurrent_expenses_paused) }}) -
+                $ {{$recurrent_expenses_paused->sum('amount')}}
+            </strong>
+        @endif
+    </div>
 </div>
 
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -74,8 +74,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/recurrent_expense/{recurrent_expense}', 'RecurrentExpenseController@edit')
         ->name('recurrent_expense.edit');
 
-    Route::delete('/recurrent_expense/{recurrent_expense}', 'RecurrentExpenseController@delete')
-        ->name('recurrent_expense.delete');
+    Route::get('/recurrent_expense/{recurrent_expense}', 'RecurrentExpenseController@stateToggle')
+        ->name('recurrent_expense.state_toggle');
 
     Route::get('/recurrent_expense', 'RecurrentExpenseController@index')
         ->name('recurrent_expense.index');


### PR DESCRIPTION
- Added a new option to pause recurrent payments for cases where you won't pay anymore however you still don't want to delete them.
- Improved redirection on Expense Create, after create the expense will redirect the user to the previous page, not only to expense.index.
- Improved redirection on Wallet update, as in expense, there are cases when the wallet is updated from the Dashboard, we will redirect the user to the dashboard if it was previously there. The idea is to improve the user experience.